### PR TITLE
[FIX] ODOO-583 Repair legacy "to date" filters.

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
@@ -7,7 +7,7 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
 
     const { DEFAULT_INTERVAL, DEFAULT_PERIOD,
         getComparisonOptions, getIntervalOptions, getPeriodOptions,
-        constructDateDomain, rankInterval, yearSelected } = require('web.searchUtils');
+        constructDateDomain, rankInterval, isOverride, yearSelected } = require('web.searchUtils');
 
     const FAVORITE_PRIVATE_GROUP = 1;
     const FAVORITE_SHARED_GROUP = 2;
@@ -533,6 +533,13 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
                     );
                 }
             } else {
+                // Override filters cannot coexist with other filters.
+                if (isOverride(optionId)) {
+                    this.state.query = this.state.query.filter(q => q.filterId !== filterId);
+                } else {
+                    this.state.query = this.state.query.filter(q => !isOverride(q.optionId));
+                }
+
                 this.state.query.push({ groupId: filter.groupId, filterId, optionId });
                 if (filter.type === 'filter' && !yearSelected(this._getSelectedOptionIds(filterId))) {
                     // Here we add 'this_year' as options if no option of type

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -13,6 +13,7 @@ import {
     getIntervalOptions,
     getPeriodOptions,
     rankInterval,
+    isOverride,
     yearSelected,
 } from "./utils/dates";
 import { FACET_ICONS } from "./utils/misc";
@@ -894,6 +895,13 @@ export class SearchModel extends EventBus {
                 );
             }
         } else {
+            // Override filters cannot coexist with other filters.
+            if (isOverride(generatorId)) {
+                this.query = this.query.filter(q => q.searchItemId !== searchItemId);
+            } else {
+                this.query = this.query.filter(q => !isOverride(q.generatorId));
+            }
+
             this.query.push({ searchItemId, generatorId });
             if (!yearSelected(this._getSelectedGeneratorIds(searchItemId))) {
                 // Here we add 'this_year' as options if no option of type


### PR DESCRIPTION
This commit adds 4 additional options for Filtering by Date. These four options
include:

- Today
- Yesterday
- Month to Date
- Year to Date

These filters can be selected on any Date field present in the Filter Drop Down
menu.

To Test:
1. Install an app that has a date for filtering - MRP (Scheduled Date)
2. Set one date in the future, and one date more than a month ago.
3. Select Year To Date
4. Date in the Future should not be shown
5. Deselect Year To Date, and select Month To Date
6. Date in the future should not be shown, as well as the date from more than a
   month ago.
7. Set the date from more than one month ago to yesterday
8. Select the Yesterday Filter
9. Only those with Yesterday's Date should be shown.
10. Select Today Filter
11. Only those with Today's Date should be shown.
