### PR TITLE
[ODOO-414][ADD] Added new view description to control panel area

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -282,6 +282,10 @@ def generate_views(action):
     # providing at least one view mode is a requirement, not an option
     view_modes = action['view_mode'].split(',')
 
+    # BLUE STINGRAY / METRIC WISE CUSTOM
+    # make sure the view_description is instantiated
+    view_description = action['view_description'] or False
+
     if len(view_modes) > 1:
         if view_id:
             raise ValueError('Non-db action dictionaries should provide '
@@ -291,7 +295,7 @@ def generate_views(action):
                 view_modes, view_id, action))
         action['views'] = [(False, mode) for mode in view_modes]
         return
-    action['views'] = [(view_id, view_modes[0])]
+    action['views'] = [(view_id, view_modes[0], view_description)]
 
 def fix_view_modes(action):
     """ For historical reasons, Odoo has weird dealings in relation to

--- a/addons/web/static/src/legacy/js/chrome/abstract_action.js
+++ b/addons/web/static/src/legacy/js/chrome/abstract_action.js
@@ -51,6 +51,17 @@ const AbstractAction = Widget.extend(ActionMixin, {
     withSearchBar: false,
 
     /**
+     * BLUE STINGRAY / METRIC WISE CUSTOM
+     * A client action might want to see the view description displayed in its
+     * control panel, or it choose not to use it.
+     *
+     * It also only makes sense if hasControlPanel is set to true.
+     *
+     * @type boolean
+     */
+    withViewDescription: false,
+
+    /**
      * This parameter can be set to customize the available sub menus in the
      * controlpanel (Filters/Group By/Favorites).  This is basically a list of
      * the sub menus that we want to use.
@@ -74,6 +85,7 @@ const AbstractAction = Widget.extend(ActionMixin, {
     init: function (parent, action, options) {
         this._super(parent);
         this._title = action.display_name || action.name;
+        this._viewDescription = action.view_description;
 
         this.searchModelConfig = {
             context: Object.assign({}, action.context),
@@ -86,6 +98,7 @@ const AbstractAction = Widget.extend(ActionMixin, {
             this.extensions.ControlPanel = {
                 actionId: action.id,
                 withSearchBar: this.withSearchBar,
+                withViewDescription: this.withViewDescription,
             };
 
             this.viewId = action.search_view_id && action.search_view_id[0];
@@ -95,6 +108,7 @@ const AbstractAction = Widget.extend(ActionMixin, {
                 breadcrumbs: options && options.breadcrumbs,
                 withSearchBar: this.withSearchBar,
                 searchMenuTypes: this.searchMenuTypes,
+                withViewDescription: this.withViewDescription,
             };
         }
     },

--- a/addons/web/static/src/legacy/js/chrome/action_mixin.js
+++ b/addons/web/static/src/legacy/js/chrome/action_mixin.js
@@ -66,6 +66,14 @@ odoo.define('web.ActionMixin', function (require) {
         _title: '',
 
         /**
+         * BLUE STINGRAY / METRIC WISE CUSTOM
+         * String containing the view description of the client action
+         *
+         * @see _setViewDescription
+         */
+        _viewDescription: '',
+
+        /**
          * @override
          */
         renderElement: function () {
@@ -155,6 +163,17 @@ odoo.define('web.ActionMixin', function (require) {
         },
 
         /**
+         * BLUE STINGRAY / METRIC WISE CUSTOM
+         * Returns a view_description that may be displayed in center of the
+         * control panel area.
+         *
+         * @returns {string}
+         */
+        getViewDescription: function () {
+            return this._viewDescription;
+        },
+
+        /**
          * Renders the buttons to append, in most cases, to the control panel (in
          * the bottom left corner). When the action is rendered in a dialog, those
          * buttons might be moved to the dialog's footer.
@@ -187,6 +206,11 @@ odoo.define('web.ActionMixin', function (require) {
                 this.controlPanelProps.title = this.getTitle();
                 delete props.title;
             }
+            if ('view_description' in props) {
+                this._setViewDescription(props.view_description);
+                this.controlPanelProps.view_description = this.getViewDescription();
+                delete props.view_description;
+            }
             if ('cp_content' in props) {
                 // cp_content has been updated: refresh it.
                 this.controlPanelProps.cp_content = Object.assign({},
@@ -210,6 +234,14 @@ odoo.define('web.ActionMixin', function (require) {
          */
         _setTitle: function (title) {
             this._title = title;
+        },
+
+        /**
+         * @private
+         * @param {string} view_description
+         */
+        _setViewDescription: function (view_description) {
+            this._viewDescription = view_description;
         },
 
         //---------------------------------------------------------------------

--- a/addons/web/static/src/legacy/js/control_panel/control_panel.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel.js
@@ -212,6 +212,7 @@ odoo.define('web.ControlPanel', function (require) {
         actionMenus: { validate: s => typeof s === 'object' || s === null, optional: 1 },
         title: { type: String, optional: 1 },
         view: { type: Object, optional: 1 },
+        view_description: { type: String, optional: 1 },
         views: Array,
         withBreadcrumbs: Boolean,
         withSearchBar: Boolean,

--- a/addons/web/static/src/legacy/js/views/abstract_view.js
+++ b/addons/web/static/src/legacy/js/views/abstract_view.js
@@ -256,6 +256,7 @@ var AbstractView = Factory.extend({
                 fields,
                 searchMenuTypes: params.searchMenuTypes,
                 view: this.fieldsView,
+                view_description: params.action.view_description || "",
                 views: params.action.views && params.action.views.filter(
                     v => v.multiRecord === this.multi_record
                 ),

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -24,6 +24,13 @@
                     </li>
                 </ol>
             </div>
+            <div class="o_cp_top_center" t-if="props.withSearchBar">
+                <div t-if="props.withBreadcrumbs" class="breadcrumb" role="navigation">
+                    <div>
+                        <p t-esc="props.view_description"/>
+                    </div>
+                </div>
+            </div>
             <div class="o_cp_top_right">
                 <div class="o_cp_searchview"
                     role="search"

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -40,6 +40,7 @@ export class ControlPanel extends Component {
         const transferredSlotNames = [
             "control-panel-top-left",
             "control-panel-top-right",
+            "control-panel-top-center",
             "control-panel-bottom-left",
             "control-panel-bottom-right",
         ];
@@ -66,13 +67,15 @@ export class ControlPanel extends Component {
         const display = Object.assign(
             {
                 "top-left": true,
+                "top-center":true,
                 "top-right": true,
                 "bottom-left": true,
                 "bottom-right": true,
             },
             this.props.display || this.env.searchModel.display.controlPanel
         );
-        display.top = display["top-left"] || display["top-right"];
+        display.top = display["top-left"] || display["top-center"] ||
+        display["top-right"];
         display.bottom = display["bottom-left"] || display["bottom-right"];
         return display;
     }

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -25,6 +25,17 @@
         }
     }
 
+    .o_cp_top_center {
+        padding-right: 20em;
+        font-size: 10px;
+    }
+
+    @media only screen and (max-width: 1026px) {
+        .o_cp_top_center {
+            display: none;
+        }
+    }
+
     .o_cp_top_right {
         min-height: $o-cp-breadcrumb-height;
     }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -9,6 +9,14 @@
                         <t t-call="web.Breadcrumbs" />
                     </t>
                 </div>
+                <div t-if="display['top-center']" class="o_cp_top_center">
+                    <t t-slot="control-panel-top-center">
+                        <t t-set="view_description" t-value="window.sessionStorage.current_action.split(':')[9].slice(1, window.sessionStorage.current_action.split(':')[9].search(','))"/>
+                        <t t-if="view_description">
+                            <p t-esc="view_description.slice(0,-1)" style="font-size: 18px;"/>
+                        </t>
+                    </t>
+                </div>
                 <div t-if="display['top-right']" class="o_cp_top_right">
                     <t t-slot="control-panel-top-right">
                         <SearchBar/>
@@ -64,5 +72,4 @@
             </li>
         </ol>
     </t>
-
 </templates>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -243,6 +243,7 @@ function makeActionManager(env) {
                 return {
                     jsId: controller.jsId,
                     name: controller.title || controller.action.name || env._t("Undefined"),
+                    view_description: controller.action.view_description || env._t("Undefined"),
                 };
             });
     }
@@ -297,6 +298,12 @@ function makeActionManager(env) {
                 const storedAction = browser.sessionStorage.getItem("current_action");
                 const lastAction = JSON.parse(storedAction || "{}");
                 if (lastAction.res_model === state.model) {
+                    if (lastAction.context) {
+                        // If this method is called because of a company switch, the
+                        // stored allowed_company_ids is incorrect.
+                        // (Fix will be improved in master)
+                        delete lastAction.context.allowed_company_ids;
+                    }
                     actionRequest = lastAction;
                     options.viewType = state.view_type;
                 }

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -37,6 +37,8 @@ class IrActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
     binding_view_types = fields.Char(default='list,form')
+    # BLUE STINGRAY / METRIC WISE CUSTOM
+    view_description = fields.Char(string='View Description')
 
     def _compute_xml_id(self):
         res = self.get_external_id()
@@ -165,7 +167,7 @@ class IrActions(models.Model):
         """
         return {
             "binding_model_id", "binding_type", "binding_view_types",
-            "display_name", "help", "id", "name", "type", "xml_id",
+            "display_name", "help", "id", "name", "type", "xml_id", "view_description",
         }
 
 
@@ -293,7 +295,7 @@ class IrActionsActWindow(models.Model):
         return super()._get_readable_fields() | {
             "context", "domain", "filter", "groups_id", "limit", "res_id",
             "res_model", "search_view", "search_view_id", "target", "view_id",
-            "view_mode", "views",
+            "view_description", "view_mode", "views",
             # `flags` is not a real field of ir.actions.act_window but is used
             # to give the parameters to generate the action
             "flags"

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -159,6 +159,7 @@
                             <field name="name"/>
                             <field name="xml_id" string="External ID"/>
                             <field name="res_model" string="Object"/>
+                            <field name="view_description"/>
                         </group>
                         <group name="action_details">
                             <field name="usage"/>
@@ -420,7 +421,7 @@ env['res.partner'].create({'name': partner_name})
                   <header>
                         <button name="action_launch"
                             states="open" string="Launch"
-                            type="object" icon="fa-cogs" class="oe_highlight" 
+                            type="object" icon="fa-cogs" class="oe_highlight"
                             help="Launch Configuration Wizard"/>
                         <button name="action_open" states="done"
                             string="Set as Todo" type="object"


### PR DESCRIPTION
### **[Add report description](https://metricwise.atlassian.net/browse/ODOO-414)**
This update adds a description area and `view_description` field to the Control Panel between the name and the Search Area.

To test:
Upgrade the modules
Turn on debug mode
Click on the debug button > Edit Action > Add a text to `view_description` > Save > Refresh page.