### PR TITLE
[IMP] sales_team: Use empty crm.team recordset instead of False.

### DIFF
--- a/addons/sales_team/models/res_users.py
+++ b/addons/sales_team/models/res_users.py
@@ -28,8 +28,4 @@ class ResUsers(models.Model):
     @api.depends('crm_team_member_ids.crm_team_id', 'crm_team_member_ids.create_date', 'crm_team_member_ids.active')
     def _compute_sale_team_id(self):
         for user in self:
-            if not user.crm_team_member_ids.ids:
-                user.sale_team_id = False
-            else:
-                sorted_memberships = user.crm_team_member_ids  # sorted by create date
-                user.sale_team_id = sorted_memberships[0].crm_team_id if sorted_memberships else False
+            user.sale_team_id = user.crm_team_member_ids[0].crm_team_id if user.crm_team_member_ids.ids else self.env['crm.team'].browse()

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -321,3 +321,6 @@ class TestMembership(TestSalesCommon):
         self.sales_team_1_m1.unlink()
         self.assertEqual(self.user_sales_leads.crm_team_ids, self.new_team)
         self.assertEqual(self.user_sales_leads.sale_team_id, self.new_team)
+
+        # ensure sale.team recordset is not false
+        self.assertFalse(self.env.ref('base.demo_user0').sale_team_id.id)


### PR DESCRIPTION
This avoids a programming error when "Multi Teams" setting is enabled; reasonable code like `if user.sale_team_id.id` no longer raises AttributeError: 'NoneType' object has no attribute 'sale_team_id'.

Submitted upstream as https://github.com/odoo/odoo/pull/159756