### PR TITLE
[FIX] Make user lookup by email case insensitive.

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -31,6 +31,7 @@ from odoo.modules.module import get_module_resource
 from odoo.osv import expression
 from odoo.service.db import check_super
 from odoo.tools import partition, collections, frozendict, lazy_property, image_process
+from odoo.tools.mail import email_escape_char
 
 _logger = logging.getLogger(__name__)
 
@@ -699,7 +700,7 @@ class Users(models.Model):
 
     @api.model
     def _get_email_domain(self, email):
-        return [('email', '=', email)]
+        return [('email', '=ilike', email_escape_char(email))]
 
     @api.model
     def _get_login_order(self):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -192,3 +192,10 @@ class TestUsers2(TransactionCase):
         # Verify that the read_group is raising an error if reified field is used as groupby
         with self.assertRaises(ValueError):
             User.read_group([], fnames + [reified_fname], [reified_fname])
+
+    def test_get_email_domain(self):
+        """ Check that _get_email_domain escapes wildcards """
+        User = self.env['res.users']
+        self.assertEqual(User._get_email_domain('\\bobs@example.com'), [('email', '=ilike', '\\\\bobs@example.com')], "backslashes should be escaped")
+        self.assertEqual(User._get_email_domain('%your@example.com'), [('email', '=ilike', '\\%your@example.com')], "percents should be escaped")
+        self.assertEqual(User._get_email_domain('_uncle@example.com'), [('email', '=ilike', '\\_uncle@example.com')], "underscores should be escaped")


### PR DESCRIPTION
This avoids user frustration when attempting to reset password via email address.