### PR TITLE
[IMP] Default References message header to Message-Id.

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -405,8 +405,7 @@ class IrMailServer(models.Model):
             else:
                 message_id = make_msgid()
         msg['Message-Id'] = message_id
-        if references:
-            msg['references'] = references
+        msg['References'] = references or message_id
         msg['Subject'] = subject
         msg['From'] = email_from
         del msg['Reply-To']


### PR DESCRIPTION
This effort follows in the footsteps of https://github.com/odoo/odoo/commit/abf993a939f9cd994896b1802fdd4f198d94fbb3 in an attempt to ensure that it is always possible to reply to an outgoing email from Odoo and have it land back on the intended thread.