### PR TITLE
[FIX] base: freeze time timezone test

### DIFF
--- a/odoo/addons/base/tests/test_tz.py
+++ b/odoo/addons/base/tests/test_tz.py
@@ -1,4 +1,5 @@
 import datetime
+from freezegun import freeze_time
 import logging
 import pytz
 from unittest.mock import patch
@@ -55,6 +56,7 @@ class TestTZ(TransactionCase):
             with self.assertRaises(ValueError):
                 self.env.user.tz = "US/Eastern"
 
+    @freeze_time('2024-11-01')
     def test_partner_with_old_tz(self):
         # this test makes sence after ubuntu noble without tzdata-legacy installed
         partner = self.env['res.partner'].create({'name': 'test', 'tz': 'UTC'})


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/186103

Versions
--------
- 15.0+

Issue
-----
`test_partner_with_old_tz` fails when ran after 2024-11-03.

Cause
-----
It checks on a hardcoded UTC offset. A timezone's UTC offset changes along with DST, which is what happened for the 'US/Eastern' timezone on 2024-11-03.

Solution
--------
Use `freeze_time` on the test, so it always runs with DST.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
