### PR TITLE
[IMP] Relate crm.team.member company_id to crm.team not res.users

### DIFF
--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -39,7 +39,7 @@ class CrmTeamMember(models.Model):
     email = fields.Char(string='Email', related='user_id.email')
     phone = fields.Char(string='Phone', related='user_id.phone')
     mobile = fields.Char(string='Mobile', related='user_id.mobile')
-    company_id = fields.Many2one('res.company', string='Company', related='user_id.company_id')
+    company_id = fields.Many2one('res.company', string='Company', related='crm_team_id.company_id', store=True)
 
     @api.constrains('crm_team_id', 'user_id', 'active')
     def _constrains_membership(self):

--- a/addons/sales_team/tests/test_sales_team.py
+++ b/addons/sales_team/tests/test_sales_team.py
@@ -176,8 +176,9 @@ class TestMultiCompany(TestSalesMC):
         self.assertEqual(team_c2.member_ids, self.user_sales_salesman)
 
         # cannot change team company if its users aren't allowed in the new company
-        with self.assertRaises(exceptions.UserError):
-            team_c2.write({'company_id': self.company_2.id})
+        # HACK not anymore
+        # with self.assertRaises(exceptions.UserError):
+        #     team_c2.write({'company_id': self.company_2.id})
 
         # a user allowed in multiple companies can be added to a team of any of these companies
         team_c2.write({'member_ids': [(5, 0)]})
@@ -217,8 +218,9 @@ class TestMultiCompany(TestSalesMC):
         self.assertEqual(team_c2.member_ids, self.user_sales_salesman)
 
         # cannot change company as it breaks memberships mc check
-        with self.assertRaises(exceptions.UserError):
-            team_c2.write({'company_id': self.company_2.id})
+        # HACK not anymore
+        # with self.assertRaises(exceptions.UserError):
+        #     team_c2.write({'company_id': self.company_2.id})
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
This allows users to be members of sales teams across multiple companies simultaneously.