### PR TITLE
[IMP] stock: Defensively specify element classes in tours.

### DIFF
--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -19,7 +19,7 @@ registry.category("web_tour.tours").add('test_detailed_op_no_save_1', {  steps: 
         run: "click",
     },
     {
-        trigger: ".fa-list",
+        trigger: ".o_list_renderer .fa-list",
         run: "click",
     },
     {
@@ -89,7 +89,7 @@ registry.category("web_tour.tours").add('test_generate_serial_1', {  steps: () =
         run: "click",
     },
     {
-        trigger: ".fa-list",
+        trigger: ".o_list_renderer .fa-list",
         run: "click",
     },
     {
@@ -188,7 +188,7 @@ registry.category("web_tour.tours").add('test_generate_serial_2', {  steps: () =
         run: "click",
     },
     {
-        trigger: ".fa-list",
+        trigger: ".o_list_renderer .fa-list",
         run: "click",
     },
     {
@@ -381,7 +381,7 @@ registry.category("web_tour.tours").add('test_add_new_line', {
             run: "click",
         },
         {
-            trigger: ".fa-list:eq(1)",
+            trigger: ".o_list_renderer .fa-list:eq(1)",
             run: "click",
         },
         {
@@ -424,7 +424,7 @@ registry.category("web_tour.tours").add("test_edit_existing_line", {
             run: "edit 2",
         },
         {
-            trigger: ".fa-list",
+            trigger: ".o_list_renderer .fa-list",
             run: "click",
         },
         {


### PR DESCRIPTION
This avoids unit test failures when the overly generic `.fa-list` matches an unexpected element instead of the "Open Move" button.